### PR TITLE
more TAC, val conflict supported in get_all_prev_cbs_var2val

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ rules_local/
 *.out
 *.dis
 *.log.*
+*.txt
+*.exe
 isa.yaml
 tmp/
 temp/

--- a/examples/dis_demo.py
+++ b/examples/dis_demo.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":  # clear; pip install -e .; python3 examples/dis_demo
     FUNC_IDX = 12  # 5: onWindowStageCreate, call loadContent and pass a mothod as para; 7: mothod that used as para
     # print(f">> before CF {dis_file.methods[FUNC_IDX]._debug_vstr()}")
     panda_re.split_native_code_block(FUNC_IDX)
-    print(f">> CF built {panda_re.dis_file.methods[FUNC_IDX]._debug_vstr()}")
+    # print(f">> CF built {panda_re.dis_file.methods[FUNC_IDX]._debug_vstr()}")
     panda_re.trans_NAC_to_TAC(method_id=FUNC_IDX)
     print(f">> TAC built {panda_re.dis_file.methods[FUNC_IDX]._debug_vstr()}")
     panda_re._code_lifting_algorithms(FUNC_IDX)
@@ -55,7 +55,7 @@ if __name__ == "__main__":  # clear; pip install -e .; python3 examples/dis_demo
     # nac_total = panda_re.get_insts_total()
     # for idx in range(panda_re.method_len()):
     #     panda_re.split_native_code_block(idx)
-    #     print(f">> [{idx}/{panda_re.method_len()}] CF built {panda_re.dis_file.methods[idx]._debug_vstr()}")
+    #     print(f">> [{idx}/{panda_re.method_len()}] CF built {panda_re.dis_file.methods[idx]}")
     #     panda_re.trans_NAC_to_TAC(method_id=idx)
     # tac_total = panda_re.get_insts_total()
     # for idx in range(panda_re.method_len()):
@@ -63,5 +63,5 @@ if __name__ == "__main__":  # clear; pip install -e .; python3 examples/dis_demo
     #     print(f">> [{idx}/{panda_re.method_len()}] after lift {panda_re.dis_file.methods[idx]._debug_vstr()}")
     # todo_tac = panda_re.get_tac_unknown_count()
     # final_tac_total = panda_re.get_insts_total()
-    # print(f"todo_tac {todo_tac}/{tac_total} {todo_tac/tac_total:.4f} / nac {nac_total} {todo_tac/nac_total:.4f}")
+    # print(f"todo_tac {todo_tac}/{tac_total} {todo_tac/tac_total:.4f} /nac /{nac_total} {todo_tac/nac_total:.4f}")
     # print(f"lifting_algorithms {final_tac_total}/{tac_total} {final_tac_total/tac_total:.4f}")

--- a/ohre/abcre/dis/AsmArg.py
+++ b/ohre/abcre/dis/AsmArg.py
@@ -21,7 +21,7 @@ class AsmArg(DebugBase):
             Log.error(f"AsmArg value is NOT valid, type {self.type_str} value {type(value)} {value}")
 
     @property
-    def len(self):
+    def len(self) -> int:
         if (len(self.name) > 0):
             return len(self.name)
         return len(self.type)
@@ -70,7 +70,7 @@ class AsmArg(DebugBase):
                 return True
         return False
 
-    def set_object_key_value(self, key: str, value: str, create=False):
+    def set_object_key_value(self, key: str, value: str, create=False) -> bool:
         if (self.type != AsmTypes.OBJECT):
             return False
         for arg in self.value:
@@ -258,7 +258,7 @@ class AsmArg(DebugBase):
             if (len(self.name) != 0 or (not isinstance(self.value, str))):
                 Log.error(f"[ArgCC] A str with name: {self.name} or value not str: {type(self.value)} {self.value}")
 
-    def _debug_str_obj(self, detail: bool = False, print_ref: bool = True):
+    def _debug_str_obj(self, detail: bool = False, print_ref: bool = True) -> str:
         out = "obj{"
         if (print_ref and self.ref_base is not None):
             out += f"{self.ref_base}->"
@@ -275,7 +275,7 @@ class AsmArg(DebugBase):
             out += "{" + self.value + "}"
         return out + "}"
 
-    def _debug_str(self, print_ref: bool = True):
+    def _debug_str(self, print_ref: bool = True) -> str:
         self._common_error_check()
 
         if (self.type == AsmTypes.OBJECT):
@@ -301,7 +301,7 @@ class AsmArg(DebugBase):
             out += f"(paras_len={self.paras_len})"
         return out
 
-    def _debug_vstr(self, print_ref: bool = True):
+    def _debug_vstr(self, print_ref: bool = True) -> str:
         self._common_error_check()
         out = ""
         if (self.type == AsmTypes.OBJECT):

--- a/ohre/abcre/dis/AsmMethod.py
+++ b/ohre/abcre/dis/AsmMethod.py
@@ -72,6 +72,10 @@ class AsmMethod(DebugBase):
         assert self.code_blocks is not None
 
     @property
+    def module_name(self) -> str:
+        return self.file_class_name
+
+    @property
     def level(self):
         return self.code_blocks.level
 
@@ -82,6 +86,10 @@ class AsmMethod(DebugBase):
     @property
     def name(self):
         return self.method_name
+
+    @property
+    def inst_len(self):
+        return self.get_insts_total()
 
     def _insert_variable_virtual_block(self):
         tac_l = list()
@@ -224,10 +232,16 @@ class AsmMethod(DebugBase):
         return ret, l_n + 1
 
     def _debug_str(self) -> str:
+        args_out = "("
+        for i in range(len(self.args) - 1):
+            ty, name = self.args[i]
+            args_out += f"{ty}:{name}, "
+        if (len(self.args)):
+            ty, name = self.args[-1]
+            args_out += f"{ty}:{name})"
         out = f"AsmMethod: {self.slotNumberIdx} {self.file_class_method_name} name {self.name} \
 {self.method_type} ret {self.return_type} [{self.file_class_name}] \
-args({len(self.args)}) {self.args} cbs({len(self.code_blocks)}) lv {self.level_str} \
-insts total {self.get_insts_total()}"
+args({len(self.args)}) {args_out} cbs({len(self.code_blocks)}) {self.level_str} insts-{self.inst_len}"
         return out
 
     def _debug_vstr(self) -> str:

--- a/ohre/abcre/dis/AsmMethod.py
+++ b/ohre/abcre/dis/AsmMethod.py
@@ -12,7 +12,7 @@ from ohre.abcre.dis.TAC import TAC
 from ohre.misc import Log, utils
 
 
-def is_label_line(s: str):  # single str in a single line endswith ":", maybe label?
+def is_label_line(s: str) -> bool:  # single str in a single line endswith ":", maybe label?
     s = s.strip()
     if (s.endswith(":")):
         if (len(s.split(" ")) == 1):  # single str in a single line endswith ":", maybe label?
@@ -20,13 +20,13 @@ def is_label_line(s: str):  # single str in a single line endswith ":", maybe la
     return False
 
 
-def is_method_end_line(s: str):
+def is_method_end_line(s: str) -> bool:
     if (s.strip() == "}"):  # process END
         return True
     return False
 
 
-def find_line_end(lines: List[str], l_n: int):
+def find_line_end(lines: List[str], l_n: int) -> int:
     l_n_end = l_n + 1
     while (l_n_end < len(lines)):
         if (is_label_line(lines[l_n_end]) or is_method_end_line(lines[l_n_end])):
@@ -84,11 +84,11 @@ class AsmMethod(DebugBase):
         return CODE_LV.get_code_name(self.code_blocks.level)
 
     @property
-    def name(self):
+    def name(self) -> str:
         return self.method_name
 
     @property
-    def inst_len(self):
+    def inst_len(self) -> int:
         return self.get_insts_total()
 
     def _insert_variable_virtual_block(self):
@@ -257,7 +257,7 @@ args({len(self.args)}) {args_out} cbs({len(self.code_blocks)}) {self.level_str} 
     def set_level(self, level):
         self.code_blocks.set_level(level)
 
-    def get_insts_total(self):
+    def get_insts_total(self) -> int:
         return self.code_blocks.get_insts_total()
 
     def get_args(self, start_pos: int = 0) -> List[AsmArg]:

--- a/ohre/abcre/dis/AsmRecord.py
+++ b/ohre/abcre/dis/AsmRecord.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Iterable, List, Tuple, Union
 
-from ohre.abcre.dis.enum.AsmTypes import AsmTypes
 from ohre.abcre.dis.DebugBase import DebugBase
+from ohre.abcre.dis.enum.AsmTypes import AsmTypes
 from ohre.misc import Log
 
 
@@ -42,7 +42,7 @@ class AsmRecord(DebugBase):
             self.file_name = self.file_class_name[:file_postfix_idx + len(".ets")].strip()
             self.class_name = self.file_class_name[file_postfix_idx + len(".ets") + 1:].strip()
 
-    def _debug_str(self):
+    def _debug_str(self) -> str:
         out = f"AsmRecord: {self.file_class_name} file_name({len(self.file_name)}) {self.file_name} \
 class_name({len(self.class_name)}) {self.class_name}: "
         for field_name, (ty, value) in self.fields.items():
@@ -52,7 +52,7 @@ class_name({len(self.class_name)}) {self.class_name}: "
                 out += f"{field_name}({ty}) {value}; "
         return out
 
-    def _debug_vstr(self):
+    def _debug_vstr(self) -> str:
         return self._debug_str()
 
 

--- a/ohre/abcre/dis/AsmString.py
+++ b/ohre/abcre/dis/AsmString.py
@@ -1,8 +1,6 @@
 from typing import Any, Dict, Iterable, List, Tuple, Union
 
-from ohre.abcre.dis.enum.AsmTypes import AsmTypes
 from ohre.abcre.dis.DebugBase import DebugBase
-from ohre.misc import Log
 
 
 class AsmString(DebugBase):
@@ -17,9 +15,9 @@ class AsmString(DebugBase):
         idx2 = line_remain.find(":")
         self.name_value = line_remain[idx2 + 1:]
 
-    def _debug_str(self):
+    def _debug_str(self) -> str:
         out = f"AsmString({hex(self.offset)}) {len(self.name_value)} {self.name_value}"
         return out
 
-    def _debug_vstr(self):
+    def _debug_vstr(self) -> str:
         return self._debug_str()

--- a/ohre/abcre/dis/CodeBlock.py
+++ b/ohre/abcre/dis/CodeBlock.py
@@ -37,7 +37,7 @@ class CodeBlock(DebugBase):  # asm instruction(NAC) cantained
     def set_var2val(self, var2val: Dict[AsmArg, AsmArg]):
         self.var2val = var2val
 
-    def get_var2val(self):
+    def get_var2val(self) -> Dict[AsmArg, AsmArg]:
         return self.var2val
 
     def empty_var2val(self):

--- a/ohre/abcre/dis/CodeBlocks.py
+++ b/ohre/abcre/dis/CodeBlocks.py
@@ -1,9 +1,8 @@
-import copy
 from typing import Any, Dict, Iterable, List, Tuple, Union
 
-from ohre.abcre.dis.enum.CODE_LV import CODE_LV
 from ohre.abcre.dis.CodeBlock import CodeBlock
 from ohre.abcre.dis.DebugBase import DebugBase
+from ohre.abcre.dis.enum.CODE_LV import CODE_LV
 from ohre.misc import Log, utils
 
 
@@ -13,7 +12,7 @@ class CodeBlocks(DebugBase):  # NAC block contained, build control flow graph in
         self.IR_level = ir_lv  # defaul: from native
 
         if (isinstance(in_l[0], CodeBlock)):  # CodeBlock in list
-            self.blocks = copy.deepcopy(in_l)
+            self.blocks = in_l
         else:  # maybe list(str) in list # anyway, try init CodeBlock using element(asm codea str list) in list
             self.blocks: List[CodeBlock] = [CodeBlock(in_l)]
 
@@ -32,7 +31,11 @@ class CodeBlocks(DebugBase):  # NAC block contained, build control flow graph in
     def level_str(self) -> str:
         return CODE_LV.get_code_name(self.IR_level)
 
-    def set_level(self, level):
+    @property
+    def inst_len(self):
+        return self.get_insts_total()
+
+    def set_level(self, level) -> bool:
         if (level >= self.IR_level):
             self.IR_level = level
             return True
@@ -44,7 +47,7 @@ class CodeBlocks(DebugBase):  # NAC block contained, build control flow graph in
         return len(self.blocks)
 
     def _debug_str(self) -> str:
-        out = f"CodeBlocks: blocks({len(self.blocks)}) {self.level_str}"
+        out = f"CodeBlocks: blocks({len(self.blocks)}) {self.level_str} insts-{self.inst_len}"
         return out
 
     def _debug_vstr(self) -> str:

--- a/ohre/abcre/dis/CodeBlocks.py
+++ b/ohre/abcre/dis/CodeBlocks.py
@@ -20,7 +20,7 @@ class CodeBlocks(DebugBase):  # NAC block contained, build control flow graph in
         return iter(self.blocks)
 
     @property
-    def len(self):
+    def len(self) -> int:
         return len(self.blocks)
 
     @property

--- a/ohre/abcre/dis/ControlFlow.py
+++ b/ohre/abcre/dis/ControlFlow.py
@@ -47,12 +47,10 @@ class ControlFlow():
                 final_nac_blocks[i].add_prev_cb(final_nac_blocks[i - 1])
 
         d_label2cb = get_label2cb(final_nac_blocks)
-        print(f"d_label2cb {d_label2cb}")
         for i in range(len(final_nac_blocks)):
             if (final_nac_blocks[i].len > 0 and (final_nac_blocks[i].insts[-1].type == NACTYPE.COND_JMP
                                                  or final_nac_blocks[i].insts[-1].type == NACTYPE.UNCN_JMP)):
                 label = final_nac_blocks[i].insts[-1].args[0]
-                print(f"label: {label} {type(label)} {label in d_label2cb.keys()}")
                 if (label in d_label2cb.keys()):
                     final_nac_blocks[i].add_next_cb(d_label2cb[label])
                     d_label2cb[label].add_prev_cb(final_nac_blocks[i])

--- a/ohre/abcre/dis/DebugBase.py
+++ b/ohre/abcre/dis/DebugBase.py
@@ -14,7 +14,7 @@ class DebugBase:
         return self._debug_str()
 
     @abstractmethod
-    def _debug_str(self):
+    def _debug_str(self) -> str:
         pass
 
     @abstractmethod

--- a/ohre/abcre/dis/DisFile.py
+++ b/ohre/abcre/dis/DisFile.py
@@ -36,6 +36,7 @@ class DisFile(DebugBase):
         self._debug: List = None
         self.lex_env: List = list()
         self.cur_lex_level: int = 0
+        self.modulevar_d: Dict[str, list] = dict()
 
         lines: List[str] = list()
         if (isinstance(value, str)):
@@ -244,8 +245,7 @@ _debug {self._debug}"
                 return lit
         return None
 
-    def get_external_module_name(
-            self, index: int, file_class_name: str = "") -> Union[str, None]:
+    def get_external_module_name(self, index: int, file_class_name: str = "") -> Union[str, None]:
         hit_cnt = 0
         hit_rec: AsmRecord = None
         if (len(file_class_name) > 0):
@@ -258,7 +258,10 @@ _debug {self._debug}"
                     ty, addr = hit_rec.fields["moduleRecordIdx"]
                     lit = self.get_literal_by_addr(addr)
                     if (lit is not None):
-                        return lit.module_request_array[index]
+                        if (index >= 0 and index < len(lit.module_request_array)):
+                            return lit.module_request_array[index]
+                        else:
+                            return None
             else:
                 Log.warn(f"get_external_module_name failed, hit_cnt {hit_cnt} \
 file_class_name {file_class_name}", True)
@@ -272,7 +275,7 @@ file_class_name {file_class_name}", True)
             print(literal_id)
             left_s = literal_id.find('[')
             right_s = literal_id.find(']')
-            literal_content = literal_id[left_s:right_s+1]
+            literal_content = literal_id[left_s:right_s + 1]
             literal_content = literal_content.split(',')
             cnt = 0
             for i in range(slots_number):
@@ -281,11 +284,11 @@ file_class_name {file_class_name}", True)
                     variable_value = literal_value[1].replace('"', '')
                 else:
                     Log.warn(f"newlexenvwithname failed. literal id format is {literal_content[cnt]}")
-                variable_name = literal_content[cnt+1].strip().split(':')
-                if len(variable_name)==2:
-                    variable_name = variable_name[1].replace('"','')
+                variable_name = literal_content[cnt + 1].strip().split(':')
+                if len(variable_name) == 2:
+                    variable_name = variable_name[1].replace('"', '')
                 else:
-                    Log.warn(f"newlexenvwithname failed. literal id format is {literal_content[cnt+1]}")
+                    Log.warn(f"newlexenvwithname failed. literal id format is {literal_content[cnt + 1]}")
                 # lex_env_layer[i] = f"[variable: {variable_name} value: {variable_value}]"
                 lex_env_layer[i] = variable_name
                 cnt += 2

--- a/ohre/abcre/dis/NAC.py
+++ b/ohre/abcre/dis/NAC.py
@@ -21,7 +21,7 @@ class NAC(DebugBase):  # N Address Code
         for i in range(1, len(op_args)):
             self.args.append(op_args[i])
 
-    def _debug_str(self):
+    def _debug_str(self) -> str:
         out = f"{self.op} "
         for i in range(len(self.args)):
             if (i == len(self.args) - 1):
@@ -30,7 +30,7 @@ class NAC(DebugBase):  # N Address Code
                 out += f"{self.args[i]}, "
         return out
 
-    def _debug_vstr(self):
+    def _debug_vstr(self) -> str:
         out = f"({NACTYPE.get_code_name(self.type)})".ljust(12, " ") + f"{self.op} "
         for i in range(len(self.args)):
             if (i == len(self.args) - 1):

--- a/ohre/abcre/dis/NACtoTAC.py
+++ b/ohre/abcre/dis/NACtoTAC.py
@@ -59,23 +59,13 @@ class NACtoTAC:
 
         # === inst: comparation instructions # START
         if (nac.op == "isin"):
-            return TAC.tac_assign(
-                AsmArg.ACC(),
-                AsmArg.build_arg(nac.args[1]),
-                AsmArg.ACC(),
-                rop="in", log=f"arg0 {nac.args[0]}")
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop="in")
         if (nac.op == "instanceof"):
-            return TAC.tac_assign(
-                AsmArg.ACC(),
-                AsmArg.build_arg(nac.args[1]),
-                AsmArg.ACC(),
-                rop="instanceof", log=f"instanceof {nac.args[0]}")
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop="instanceof")
         if (nac.op == "stricteq"):
-            return TAC.tac_assign(AsmArg.ACC(), AsmArg.ACC(), AsmArg.build_arg(nac.args[1]),
-                                  rop="===", log=f"stricteq arg0 {nac.args[0]}")
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), rop="===")
         if (nac.op == "strictnoteq"):
-            return TAC.tac_assign(AsmArg.ACC(), AsmArg.ACC(), AsmArg.build_arg(nac.args[1]),
-                                  rop="!==", log=f"strictnoteq arg0 {nac.args[0]}")
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), rop="!==")
         # === inst: comparation instructions # END
 
         # === inst: unary operations # START
@@ -114,7 +104,20 @@ class NACtoTAC:
             return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop=">")
         if (nac.op == "greatereq"):
             return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop=">=")
-
+        if (nac.op == "shl2"):
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop="<<")
+        if (nac.op == "shr2"):
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop=">>>")
+        if (nac.op == "ashr2"):
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop=">>")
+        if (nac.op == "and2"):
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop="&")
+        if (nac.op == "or2"):
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop="|")
+        if (nac.op == "xor2"):
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop="^")
+        if (nac.op == "exp"):
+            return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop="**")
         if (nac.op == "add2"):
             return TAC.tac_assign(AsmArg.ACC(), AsmArg.build_arg(nac.args[1]), AsmArg.ACC(), rop="+")
         if (nac.op == "sub2"):
@@ -225,8 +228,10 @@ class NACtoTAC:
                 for i in range(arg_len):
                     paras.append(arg)
                     arg = arg.build_next_arg()
-            return TAC.tac_call(arg_len=AsmArg(AsmTypes.IMM, value=arg_len), paras=paras,
-                                call_addr=AsmArg(AsmTypes.METHOD, name="__super"))
+            inst_call = TAC.tac_call(arg_len=AsmArg(AsmTypes.IMM, value=arg_len), paras=paras,
+                                     call_addr=AsmArg(AsmTypes.METHOD, name="__super"), ret_store_to=AsmArg.NULL())
+            inst_ret = TAC.tac_assign(AsmArg.ACC(), AsmArg.build_this(), log="TODO: __super return ptr this?")
+            return [inst_call, inst_ret]
         if (nac.op == "wide.supercallthisrange"):
             arg_len = int(nac.args[0], 16)
             paras = list()
@@ -256,16 +261,14 @@ class NACtoTAC:
             call_addr = AsmArg.build_arg(nac.args[2])
             arg = call_addr
             paras = list()
-            for i in range(arg_len):
+            for i in range(arg_len - 1):
                 arg = arg.build_next_arg()
                 paras.append(arg)
-            return TAC.tac_call(ret_store_to=AsmArg.ACC(), call_addr=call_addr,
-                                arg_len=AsmArg(AsmTypes.IMM, value=int(nac.args[1], 16)), paras=paras)
+            return TAC.tac_call(AsmArg(AsmTypes.IMM, value=int(nac.args[1], 16)), paras, call_addr=call_addr)
         if (nac.op == "createobjectwithbuffer"):
             kv_dict = AsmLiteral.literal_get_key_value("{" + nac.args[1] + "}")
             arg_obj = AsmArg.build_object(kv_dict)
-            print(f"createobjectwithbuffer-arg_obj {type(arg_obj)} {arg_obj}")
-            return TAC.tac_assign(AsmArg.ACC(), arg_obj, log="createobjectwithbuffer d3bug")
+            return TAC.tac_assign(AsmArg.ACC(), arg_obj)
         if (nac.op == "newlexenv"):
             slots = int(nac.args[0], base=16)
             cur_lex_env = dis_file.create_lexical_environment(slots)
@@ -273,7 +276,7 @@ class NACtoTAC:
         if (nac.op == "newlexenvwithname"):
             slots = int(nac.args[0], base=16)
             literal_id = nac.args[1]
-            cur_lex_env = dis_file.create_lexical_environment(slots,literal_id=literal_id)
+            cur_lex_env = dis_file.create_lexical_environment(slots, literal_id=literal_id)
             return TAC.tac_assign(AsmArg.ACC(), AsmArg(AsmTypes.LEXENV, value=str(cur_lex_env)))
         # === inst: object creaters # END
 
@@ -284,7 +287,11 @@ class NACtoTAC:
         if (nac.op == "tryldglobalbyname"):
             return TAC.tac_assign(
                 AsmArg.ACC(), AsmArg.build_object(None, name=utils.strip_sted_str(nac.args[1])),
-                log=f"// todo: check tryldglobalbyname, not throw now")
+                log=f"todo: ld global var, not throw now")
+        if (nac.op == "trystglobalbyname"):
+            return TAC.tac_assign(
+                AsmArg.build_object(None, name=utils.strip_sted_str(nac.args[1])), AsmArg.ACC(),
+                log=f"todo: st global var, not throw now")
         if (nac.op == "ldexternalmodulevar"):
             index = int(nac.args[0], base=16)
             module_name = dis_file.get_external_module_name(index, meth.file_class_name)
@@ -298,15 +305,16 @@ class NACtoTAC:
             dest = AsmArg(AsmTypes.FIELD, name=utils.strip_sted_str(nac.args[1]),
                           ref_base=AsmArg.build_arg(utils.strip_sted_str(nac.args[2])))
             return TAC.tac_assign(dest, AsmArg.ACC())
-        if (nac.op == "stmodulevar"):
-            pass  # TODO: global var related
+        if (nac.op == "stmodulevar"):  # TODO: global var related
+            return TAC.tac_call(AsmArg(AsmTypes.IMM, value=2),
+                                [AsmArg(AsmTypes.IMM, value=int(nac.args[0], 16)), AsmArg.ACC()],
+                                call_addr=AsmArg(AsmTypes.METHOD, name="__stmodulevar"),
+                                ret_store_to=AsmArg.NULL())
         if (nac.op == "asyncfunctionresolve"):
-            return TAC.tac_call(AsmArg(AsmTypes.IMM, value=1), [AsmArg.build_arg(nac.args[0]), AsmArg.ACC()],
-                                ret_store_to=AsmArg.ACC(),
+            return TAC.tac_call(AsmArg(AsmTypes.IMM, value=2), [AsmArg.build_arg(nac.args[0]), AsmArg.ACC()],
                                 call_addr=AsmArg(AsmTypes.METHOD, name="__asyncfunctionresolve"))
         if (nac.op == "asyncfunctionreject"):
             return TAC.tac_call(AsmArg(AsmTypes.IMM, value=2), [AsmArg.build_arg(nac.args[0]), AsmArg.ACC()],
-                                ret_store_to=AsmArg.ACC(),
                                 call_addr=AsmArg(AsmTypes.METHOD, name="__asyncfunctionreject"))
         if (nac.op == "stlexvar"):
             lexenv_layer = int(nac.args[0], base=16)
@@ -321,6 +329,13 @@ class NACtoTAC:
         # === inst: object visitors # END
 
         # === inst: definition instuctions # START
+        if (nac.op == "definegettersetterbyvalue"):
+            # definegettersetterbyvalue v1: object, v2: key of v1, v3: getter METHOD_OBJ, v4: setter METHOD_OBJ
+            # acc-in: bool, Whether to set a name for the accessor # acc-out:
+            return TAC.tac_call(AsmArg(AsmTypes.IMM, value=5),
+                                [AsmArg.ACC(), AsmArg.build_arg(nac.args[0]), AsmArg.build_arg(nac.args[1]),
+                                 AsmArg.build_arg(nac.args[2]), AsmArg.build_arg(nac.args[3])],
+                                call_addr=AsmArg(AsmTypes.METHOD, name="__definegettersetterbyvalue"))
         if (nac.op == "definefunc"):
             return TAC.tac_assign(
                 AsmArg.ACC(),
@@ -332,11 +347,15 @@ class NACtoTAC:
             inst1 = TAC.tac_assign(AsmArg.ACC(),
                                    AsmArg(AsmTypes.METHOD_OBJ, value=nac.args[1], paras_len=paras_len))
             return [inst0, inst1]
-        if (nac.op == "definegettersetterbyvalue"):
-            # definegettersetterbyvalue v1: object, v2: key of v1, v3: getter METHOD_OBJ, v4: setter METHOD_OBJ
-            # acc-in: bool, Whether to set a name for the accessor # acc-out:
-            # return [inst0, inst1]
-            pass
+        if (nac.op == "defineclasswithbuffer"):
+            constructor_str = AsmArg(AsmTypes.STR, value=nac.args[1])
+            class_lit = AsmArg(AsmTypes.STR, value=nac.args[2])
+            class_para_len = AsmArg(AsmTypes.IMM, value=int(nac.args[3], 16))
+            parent_class = AsmArg.build_arg(nac.args[4])
+            return TAC.tac_call(
+                AsmArg(AsmTypes.IMM, value=4),
+                [constructor_str, class_lit, class_para_len, parent_class],
+                call_addr=AsmArg(AsmTypes.METHOD, name="__defineclasswithbuffer"))
         # === inst: definition instuctions # END
 
         # === inst: iterator instructions # START
@@ -355,10 +374,11 @@ class NACtoTAC:
             log=f"todo: {nac.op} {[nac.args[i] for i in range(len(nac.args))]}")
 
     @classmethod
-    def trans_NAC_to_TAC(cls, meth: AsmMethod, dis_file: DisFile) -> CodeBlocks:
+    def trans_NAC_to_TAC(cls, meth: AsmMethod, dis_file: DisFile) -> bool:
         cbs = meth.code_blocks
-        assert cbs.level == CODE_LV.NATIVE_BLOCK_SPLITED
-        cbs_l = list()
+        if (cbs.level != CODE_LV.NATIVE_BLOCK_SPLITED):
+            Log.error(f"cbs level is NOT NATIVE_BLOCK_SPLITED")
+            return False
         for i in range(len(cbs.blocks)):
             tac_inst_l = list()
             for nac_inst in cbs.blocks[i].insts:
@@ -373,3 +393,4 @@ class NACtoTAC:
                         print(f"tac^: {tac._debug_vstr()}")
                         tac_inst_l.append(tac)
             cbs.blocks[i].insts = tac_inst_l
+        return True

--- a/ohre/abcre/dis/TAC.py
+++ b/ohre/abcre/dis/TAC.py
@@ -7,7 +7,7 @@ from ohre.abcre.dis.enum.TACTYPE import TACTYPE
 from ohre.misc import Log, utils
 
 
-def in_and_not_None(key, d: Dict):
+def in_and_not_None(key, d: Dict) -> bool:
     if (key in d.keys() and d[key] is not None):
         if (isinstance(d[key], AsmArg)):
             if (not d[key].is_unknown()):
@@ -36,7 +36,7 @@ class TAC(DebugBase):  # Three Address Code
         self.this: AsmArg = this  # this pointer, maybe point to a object/module
 
     @property
-    def type(self):
+    def type(self) -> TACTYPE:
         return self.optype
 
     @property

--- a/ohre/abcre/dis/TAC.py
+++ b/ohre/abcre/dis/TAC.py
@@ -7,6 +7,18 @@ from ohre.abcre.dis.enum.TACTYPE import TACTYPE
 from ohre.misc import Log, utils
 
 
+def in_and_not_None(key, d: Dict):
+    if (key in d.keys() and d[key] is not None):
+        if (isinstance(d[key], AsmArg)):
+            if (not d[key].is_unknown()):
+                return True
+            else:
+                return False
+        else:
+            return True
+    return False
+
+
 class TAC(DebugBase):  # Three Address Code
     def __init__(self, optype=TACTYPE.UNKNOWN, args: List[AsmArg] = None,
                  rop: str = "", log: str = "", this: AsmArg = None):
@@ -70,8 +82,9 @@ class TAC(DebugBase):  # Three Address Code
 
     @classmethod
     def tac_call(cls, arg_len: AsmArg = None, paras: List[AsmArg] = None, this: AsmArg = None,
-                 ret_store_to: AsmArg = AsmArg(AsmTypes.ACC), call_addr: AsmArg = AsmArg(AsmTypes.ACC), log: str = ""):
-        # call always assign acc = return value # so for all panda call, ret_store_to = acc
+                 ret_store_to: AsmArg = AsmArg.ACC(), call_addr: AsmArg = AsmArg.ACC(), log: str = ""):
+        # ArkTS's call always assign acc = return value # so for all panda call, ret_store_to = acc
+        # some self defined(this proj) func call's return value is NOT stored to acc, may be NOT stored
         return TAC(TACTYPE.CALL, [ret_store_to, call_addr, arg_len, *paras], this=this, log=log)
 
     @classmethod
@@ -82,7 +95,7 @@ class TAC(DebugBase):  # Three Address Code
     def tac_unknown(cls, paras: List[AsmArg] = None, log: str = ""):
         return TAC(TACTYPE.UNKNOWN, paras, log=log)
 
-    def _args_and_rop_common_debug_vstr(self):
+    def _args_and_rop_common_debug_vstr(self) -> str:
         out = f""
         for i in range(len(self.args)):
             out += f"{self.args[i]._debug_vstr()} "
@@ -90,14 +103,13 @@ class TAC(DebugBase):  # Three Address Code
                 out += f"({self.rop}) "
         return out
 
-    def _debug_str_call(self):
+    def _debug_str_call(self) -> str:
         out = ""
-        if (self.args[0] is not None and len(self.args[0]) > 0):
+        if (self.args[0] is not None and (not self.args[0].is_null()) and len(self.args[0]) > 0):
             out += f"{self.args[0]} = "
-        else:
-            Log.error(f"self.args[0] is None at a CALL inst. return value store to None?")
         if (self.this is not None and len(self.this) > 0):
-            out += f"{self.this}->"
+            out += f"{self.this._debug_str(print_ref=True)}-> "
+        # NOTE: if called by T->acc, acc may have same ref with T, then output will be T->T->acc, changed to T->acc
         out += f"{self.args[1]._debug_str(print_ref=False)}("
         for i in range(3, len(self.args)):
             if (i == self.args_len - 1):
@@ -111,20 +123,21 @@ class TAC(DebugBase):  # Three Address Code
             out += f" // call-args len is None"
         return out
 
-    def _debug_vstr_call(self):
+    def _debug_vstr_call(self) -> str:
         out = ""
         if (self.args[0] is not None and len(self.args[0]) > 0):
             out += f"{self.args[0]._debug_vstr()} = "
-        else:
-            Log.error(f"self.args[0] is None at a CALL inst. return value store to None?")
         if (self.this is not None and len(self.this) > 0):
-            out += f"{self.this._debug_vstr()}->"
+            out += f"{self.this._debug_vstr()}-> "
         out += f"{self.args[1]._debug_vstr(print_ref=True)}("
         for i in range(3, self.args_len):
-            if (i == self.args_len - 1):
-                out += f"{self.args[i]._debug_vstr()}"
+            if (self.args[i] is not None):
+                if (i == self.args_len - 1):
+                    out += f"{self.args[i]._debug_vstr()}"
+                else:
+                    out += f"{self.args[i]._debug_vstr()}, "
             else:
-                out += f"{self.args[i]._debug_vstr()}, "
+                out += f" None "
         out += ")"
         if (self.args[2] is not None):  # arg len
             out += f" // call-args({self.args[2].value})"
@@ -132,7 +145,7 @@ class TAC(DebugBase):  # Three Address Code
             out += f" // call-args len is None"
         return out
 
-    def _debug_str(self):
+    def _debug_str(self) -> str:
         out = ""
         if (self.optype == TACTYPE.ASSIGN):
             if (len(self.args) == 2 and len(self.rop) == 0):
@@ -167,7 +180,7 @@ class TAC(DebugBase):  # Three Address Code
             out += " //!UNKNOWN TAC"
         return out
 
-    def _debug_vstr(self):
+    def _debug_vstr(self) -> str:
         out = f"[{TACTYPE.get_code_name(self.optype)}]".ljust(12, " ")
         if (self.optype == TACTYPE.ASSIGN):
             if (len(self.args) == 2 and len(self.rop) == 0):
@@ -219,7 +232,7 @@ throw {self.args[2]._debug_vstr()}"
             else:
                 Log.error(f"get_def_use ERROR {self.type_str} {self._debug_vstr()}")
             # NOTE: if v10[xxx] = yyy, xxx is def-ed, v10 is def-ed, and v10 is also used here
-            if (self.args[0].is_has_ref()):
+            if (self.args[0].has_ref()):
                 use_vars.update(self.args[0].ref_base.get_all_args_recursively())
         elif (self.type == TACTYPE.IMPORT):  # acc = module(x)
             if (len(self.args) == 2):
@@ -304,7 +317,7 @@ throw {self.args[2]._debug_vstr()}"
             if (self.args[i] == old_var):
                 self.args[i] = new_var
                 print(f"replace_use_var i={i} old_var {old_var} new_var {new_var}")
-            elif (include_ref and self.args[i].is_has_ref() and self.args[i].ref_base == old_var):
+            elif (include_ref and self.args[i].has_ref() and self.args[i].ref_base == old_var):
                 self.args[i].set_ref(new_var)
                 print(f"replace_use_var-ref i={i} old_var {old_var._debug_vstr()} new_var {new_var}")
             i += 1
@@ -328,19 +341,22 @@ throw {self.args[2]._debug_vstr()}"
     def copy_propagation(self, var2val: Dict[AsmArg, AsmArg], include_ref: bool = True):
         if (self.is_arg0_def()):
             i = 1
+            # v1["xx"] = v2 # v1=this in var2val
+            if (self.args[0].has_ref() and in_and_not_None(self.args[0].ref_base, var2val)):
+                self.args[0].ref_base = var2val[self.args[0].ref_base]
         else:
             i = 0
-        print(f"copy_propagation i={i} inst {self._debug_vstr()} var2val {var2val}")
+        print(f"copy_propagation-TAC-START i={i} inst {self._debug_vstr()} var2val {var2val}")
         while (i < self.args_len):
-            if (utils.in_and_not_None(self.args[i], var2val)):
+            if (in_and_not_None(self.args[i], var2val)):
                 print(f"copy_propagation  {self.args[i]} => {var2val[self.args[i]]}; {self._debug_str()}")
                 self.args[i] = var2val[self.args[i]]
-            elif (include_ref and self.args[i].is_has_ref() and utils.in_and_not_None(self.args[i].ref_base, var2val)):
+            elif (include_ref and self.args[i].has_ref() and in_and_not_None(self.args[i].ref_base, var2val)):
                 print(f"copy_propagation-ref {self.args[i].ref_base._debug_vstr()} => \
 {var2val[self.args[i].ref_base]._debug_vstr()}; {self._debug_str()}")
                 self.args[i].set_ref(var2val[self.args[i].ref_base])
             i += 1
         if (self.type == TACTYPE.CALL and self.this is not None):
-            if (utils.in_and_not_None(self.this, var2val)):
+            if (in_and_not_None(self.this, var2val)):
                 print(f"copy_propagation-this  {self.this} => {var2val[self.this]}; {self._debug_str()}")
                 self.this = var2val[self.this]

--- a/ohre/abcre/dis/enum/NACTYPE.py
+++ b/ohre/abcre/dis/enum/NACTYPE.py
@@ -5,7 +5,7 @@ from ohre.abcre.enum.BaseEnum import BaseEnum
 from ohre.misc import Log, utils
 
 
-def _value_in_key_of_dict(d: dict, key, value):
+def _value_in_key_of_dict(d: dict, key, value) -> bool:
     if (key in d.keys() and d[key] is not None and value in d[key]):
         return True
     return False

--- a/ohre/abcre/dis/enum/NACTYPE.py
+++ b/ohre/abcre/dis/enum/NACTYPE.py
@@ -104,10 +104,6 @@ class NACTYPE(BaseEnum):
 
 if __name__ == "__main__":
     NACTYPE.init_from_ISAyaml(os.path.join(os.path.dirname(os.path.abspath(__file__)), "isa.yaml"))
-    # for inst in [
-    #     "mov", "return", "ldobjbyname", "jeqz", "jnez", "jstricteq", "jnstricteq", "throw", "throw.notexists",
-    #         "throw.ifnotobject"]:
-    #     print(f"inst {inst}: {NACTYPE.get_code_name(NACTYPE.get_NAC_type(inst))}")
     print(f"op total count: {len(NACTYPE.isa.opstr2infod)}")
     for inst in NACTYPE.isa.opstr2infod.keys():
         print(f"inst {inst}: {NACTYPE.get_code_name(NACTYPE.get_NAC_type(inst))}")

--- a/ohre/abcre/dis/lifting/CopyPropagation.py
+++ b/ohre/abcre/dis/lifting/CopyPropagation.py
@@ -5,38 +5,38 @@ from ohre.abcre.dis.AsmArg import AsmArg
 from ohre.abcre.dis.AsmMethod import AsmMethod
 from ohre.abcre.dis.CodeBlock import CodeBlock
 from ohre.abcre.dis.enum.TACTYPE import TACTYPE
-from ohre.abcre.dis.lifting.LivingVar import _update_cbs_def_use_vars_reverse
-from ohre.abcre.dis.TAC import TAC
+from ohre.abcre.dis.TAC import TAC, in_and_not_None
 from ohre.misc import Log, utils
-from ohre.misc.utils import in_and_not_None
 
 
 def CopyPropagation(meth: AsmMethod):
-    print(f"\n\n>>> CPro-START {meth.name} {meth.level_str} {meth._debug_vstr()}")
+    print(f"\n\n>>> CPro-START {meth.name} {meth._debug_vstr()}")
     for cb in meth.code_blocks:
         cb.empty_var2val()
+    i = 0
     for cb in meth.code_blocks:
         var2val = CPro_cb(cb)
         cb.set_var2val(var2val)
-        CPro_cb(cb)  # now var2val in cb updated, CPro it again
-    print(f">>> CPro-END {meth.name} {meth.level_str} {meth._debug_vstr()}")
+        CPro_cb(cb, DEBUG_MSG=f"CPro_{i}_{len(meth.code_blocks)}")  # now var2val in cb updated, CPro it again
+        i += 1
+    print(f">>> CPro-END {meth.name} {meth._debug_vstr()}")
 
 
-def CPro_cb(cb: CodeBlock) -> Dict[AsmArg, AsmArg]:
+def CPro_cb(cb: CodeBlock, DEBUG_MSG: str = "") -> Dict[AsmArg, AsmArg]:
+    print(f"\n\n ===================================== {DEBUG_MSG}")
     var2val: Dict[AsmArg, AsmArg] = cb.get_all_prev_cbs_var2val(get_current_cb=False, definite_flag=True)
-    print(f"\n >>>> CPro_cb START cb: {cb._debug_vstr()} var2val {var2val}")
+    print(f"\n >>>> CPro_cb START {DEBUG_MSG} cb: {cb._debug_vstr()} var2val {var2val}")
     for i in range(cb.get_insts_len()):
         inst = cb.insts[i]
         print(f"CPro_cb inst START inst {inst} {inst._debug_vstr()} var2val {var2val}")
         inst.copy_propagation(var2val)
-        if (not inst.is_arg0_def()):
+        if (not inst.is_arg0_def()):  # NOTE: skip a inst that not assign any arg (if assigned, must be arg0)
             continue
         if ((inst.is_simple_assgin() and inst.args[0].is_no_ref()) or inst.type == TACTYPE.IMPORT):
             var2val[inst.args[0]] = inst.args[1]
-        elif (inst.args[0].is_has_ref() and inst.args[0].is_field()
+        elif (inst.args[0].has_ref() and inst.args[0].is_field()
                 and in_and_not_None(inst.args[0].ref_base, var2val)
                 and var2val[inst.args[0].ref_base].obj_has_key(inst.args[0])):
-            print(f"TODO: check inst {inst._debug_vstr()} ref {inst.args[0].ref_base._debug_vstr()}")
             print(f"before {var2val[inst.args[0].ref_base]}")
             ret = var2val[inst.args[0].ref_base].set_object_key_value(inst.args[0].name, inst.args[1])
             print(f"after  {var2val[inst.args[0].ref_base]} {ret}")
@@ -55,10 +55,10 @@ def CPro_cb(cb: CodeBlock) -> Dict[AsmArg, AsmArg]:
         elif (inst.type == TACTYPE.CALL):
             if (inst.args[0] in var2val):
                 var2val[inst.args[0]] = None
-        else:
+        else:  # TODO: if hit here, something need to be check, and support it!
             if (inst.args[0] in var2val):
                 var2val[inst.args[0]] = None
             Log.error(f"ERROR-CPro_cb! else hit, inst {inst} is_arg0_def {inst.is_arg0_def()} var2val {var2val}")
         print(f"CPro_cb inst END inst {inst} {inst._debug_vstr()} var2val {var2val}")
-    print(f"\n >>>> CPro_cb END cb: var2val {var2val}")
+    print(f"\n >>>> CPro_cb END {DEBUG_MSG} // var2val {var2val}")
     return var2val

--- a/ohre/abcre/dis/lifting/DeadCodeElimination.py
+++ b/ohre/abcre/dis/lifting/DeadCodeElimination.py
@@ -16,27 +16,29 @@ def DeadCodeElimination(meth: AsmMethod):
     # eliminate the var def but not used inside that code block and the following cbs
     # 1-Delete Dead Code: 1. def in cb 2. NOT used in cb and all next cbs
     # 2-Delete Dead Code: TODO: delete code def in the front but not used and then redef later
-    print(f"\nDCE-START {meth.name} {meth.level_str}")
+    print(f"\n DCE-START {meth.name} {meth.level_str}")
 
     old_insts_len, new_insts_len = -1, 0
     while (old_insts_len != new_insts_len):
         old_insts_len = meth.get_insts_total()
         _update_cbs_def_use_vars_reverse(meth)
+        i = 0
         for cb in meth.code_blocks:
-            DCE_cb_reverse(cb)
-            print(f"DCE_cb_reverse END cb: {cb._debug_vstr()}\n")
+            DCE_cb_reverse(cb, DEBUG_MSG=f"DCE_{i}_{len(meth.code_blocks)}")
+            i += 1
         new_insts_len = meth.get_insts_total()
-    print(f"DCE-END {meth.name} {meth.level_str}\n\n ")
+    print(f"DCE-END {meth.name} {meth.level_str}\n\n")
 
 
-def DCE_cb_reverse(cb: CodeBlock):  # DCE is short for DeadCodeElimination
+def DCE_cb_reverse(cb: CodeBlock, DEBUG_MSG: str = ""):  # DCE is short for DeadCodeElimination
     # NOTE: reverse order traversal: update vars used into `used_after`
     # if a inst def a var NOT used at `used_after`, mark it as pending delete index set
-    print(f"DCE_cb_reverse START cb: {cb} all_next_cbs_use_vars {cb.get_all_next_cbs_use_vars()}")
-    # Step-1: reverse order, add inst that def a var not in current `used_after` into pending set
     used_after: set[AsmArg] = cb.get_all_next_cbs_use_vars(get_current_cb=False)
+    print(f"DCE_cb_reverse START {DEBUG_MSG} cb: {cb} used_after {used_after}")
+
+    # Step-1: add inst that [def a var not in current `used_after`] into pending set (in reverse order)
     pending_delete_inst_idxs: set = set()
-    for i in range(cb.get_insts_len() - 1, -1, -1):
+    for i in range(cb.inst_len - 1, -1, -1):
         def_vars_inst, use_vars_inst = cb.insts[i].get_def_use_list()
         used_after.update(use_vars_inst)
         used_after_flag = False  # var def in this inst is used after this inst or not
@@ -44,12 +46,12 @@ def DCE_cb_reverse(cb: CodeBlock):  # DCE is short for DeadCodeElimination
             if (var in used_after):  # if one var in def_vars_inst used, then this inst cannot be deleted
                 used_after_flag = True
                 break
-        if (used_after_flag == False):
+        if (used_after_flag == False):  # all def-ed var in this inst are not used after
             pending_delete_inst_idxs.add(i)
-        # if (len(def_vars_inst) == 1 and def_vars_inst[0].is_temp_var_like()): # TODO: bug, cannot discard derictly
-        #     # if a var def in curr inst, then for previous inst, var not used # NOTE: must be placed in the last
-        #     print(f"DCE_cb_reverse d3bug inst {cb.insts[i]} def_vars_inst {def_vars_inst} use_vars_inst {use_vars_inst} used_after {used_after}")
-        #     used_after.discard(def_vars_inst[0])
+        if (len(def_vars_inst) == 1 and def_vars_inst[0] not in use_vars_inst and def_vars_inst[0].is_acc()):
+            # TODO: more test needed, more situation needed # NOTE: must be placed in the last
+            # if a var def in this inst, but: 1. not used in this inst; 2. is ACC
+            used_after.discard(def_vars_inst[0])
     cb.set_use_vars(used_after)
 
     # Step-2: determine: if idxs in pending delete inst idxs actually need to be deleted
@@ -61,5 +63,6 @@ def DCE_cb_reverse(cb: CodeBlock):  # DCE is short for DeadCodeElimination
                 delete_inst_idx.add(i)
                 continue
         tac_l.append(cb.insts[i])  # NOT delete
-    print(f"DCE_cb_reverse delete_inst_idx {delete_inst_idx}")
+    print(f"DCE_cb_reverse {DEBUG_MSG} delete_inst_idx {delete_inst_idx}")
     cb.replace_insts(tac_l)
+    print(f"DCE_cb_reverse END {DEBUG_MSG} {cb._debug_vstr()}\n")

--- a/ohre/abcre/dis/lifting/PeepholeOptimization.py
+++ b/ohre/abcre/dis/lifting/PeepholeOptimization.py
@@ -8,13 +8,13 @@ from ohre.abcre.dis.TAC import TAC
 
 
 def PeepholeOptimization(meth: AsmMethod):
-    print(f"PHO-START {meth.name} {meth.level_str}")
+    print(f"PHO-START {meth.name}")
     for cb in meth.code_blocks:
         PHO_cb(cb)
         _update_cbs_def_use_vars_reverse(meth)
         PHO_cb_reverse(cb)  # e.g. a=xxx; b=a; a not used later
-        print(f"PHO_cb-END {cb._debug_vstr()}")
-    print(f"PHO-END {meth.name} {meth.level_str}")
+        print(f"PHO_cb-END {cb._debug_str()}")
+    print(f"PHO-END {meth.name} {meth._debug_vstr()}")
 
 
 def PHO_cb(cb: CodeBlock):
@@ -104,5 +104,5 @@ def update_cb_insts(cb: CodeBlock, idx_old2new: Dict[int, int], new_idx2inst: Di
             print(f"PHO-inst_delete {i} {cb.insts[i]}")
             continue  # this old inst point to a new inst idx that already append
         else:
-            tac_l.append(cb.insts[i])  # no op, just store it
+            tac_l.append(cb.insts[i])  # no operation, just store it
     cb.replace_insts(tac_l)

--- a/ohre/misc/Log.py
+++ b/ohre/misc/Log.py
@@ -6,7 +6,7 @@ from logging.handlers import RotatingFileHandler
 
 g_log = None
 DEBUG_LOCAL = True
-DEBUG_LEN = 300
+DEBUG_LEN = 500
 
 
 def debug_print(logstr: str, level: str = "debug"):

--- a/ohre/misc/utils.py
+++ b/ohre/misc/utils.py
@@ -1,4 +1,3 @@
-import copy
 from typing import Any, Dict, Iterable, List, Tuple, Union
 
 import yaml
@@ -155,12 +154,6 @@ def strip_sted_str(in_str: str, start_str: str = "\"", end_str: str = "\""):
     if (in_str.endswith(end_str)):
         out = out[:-len(end_str)]
     return out
-
-
-def in_and_not_None(key, d: Dict):
-    if (key in d.keys() and d[key] is not None):
-        return True
-    return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
more TAC builder
value conflict supported (fix) in get_all_prev_cbs_var2val
previous CBs's value related supported in copy_propagation
// If var's value is not the same among each chain of previous CBs, set it as None
some coding standards/formats updated